### PR TITLE
Fix segfault in wad extraction

### DIFF
--- a/croctool/wad_extract.c
+++ b/croctool/wad_extract.c
@@ -79,7 +79,7 @@ int wad_extract(int argc, char **argv)
 done:
 
     if(data)
-        free(data);
+        vsc_free(data);
 
     if(wadfs != NULL)
         croc_wadfs_close(wadfs);

--- a/croctool/wad_extract_all.c
+++ b/croctool/wad_extract_all.c
@@ -68,7 +68,7 @@ int wad_extract_all(int argc, char **argv)
 
 next:
         if(data != NULL)
-            free(data);
+            vsc_free(data);
         data = NULL;
 
         if(fp2 != NULL)


### PR DESCRIPTION
When `croc_wad_load_entry` was updated to use `vsc_malloc` (in [3ffd5a5](https://github.com/vs49688/CrocUtils/commit/3ffd5a5152bf7f1272c364044c068f2ed3f68a98)), croctool's calls to `free` were not updated to match, leading to a segfault when extracting files. This fixes that.